### PR TITLE
Enable TGN identifiers as objects of cto:relatedLocation

### DIFF
--- a/base/data.py
+++ b/base/data.py
@@ -29,6 +29,7 @@ RISM = Namespace('https://rism.online/')
 FG = Namespace('https://database.factgrid.de/entity/')
 ISIL = Namespace('https://ld.zdb-services.de/resource/organisations/')
 SCHEMA = Namespace('http://schema.org/')
+TGN = Namespace('https://vocab.getty.edu/tgn/')
 
 
 class Uri:
@@ -1008,7 +1009,8 @@ def clean_namespaces(input:str) -> str:
         str(VIAF),
         str(RISM),
         str(FG),
-        str(ISIL)
+        str(ISIL),
+        str(TGN)
     ]
 
     # Prepare additional http/https check if not a regular namespace

--- a/base/lookup.py
+++ b/base/lookup.py
@@ -33,6 +33,7 @@ RISM_API = Namespace('https://rism.online/api/v1#')
 SCHEMA = Namespace('http://schema.org/')
 VIAF = Namespace('http://viaf.org/viaf/')
 WD = Namespace('http://www.wikidata.org/entity/')
+TGN = Namespace('https://vocab.getty.edu/tgn/')
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -98,6 +99,10 @@ class Lookup:
 
         # GeoNames
         elif URIRef(uri) in GN:
+            output = 'location'
+
+        # TGN
+        elif URIRef(uri) in TGN:
             output = 'location'
 
         # Iconclass

--- a/map/cto.py
+++ b/map/cto.py
@@ -33,6 +33,7 @@ RISM = Namespace('https://rism.online/')
 SCHEMA = Namespace('http://schema.org/')
 VIAF = Namespace('http://viaf.org/viaf/')
 WD = Namespace('http://www.wikidata.org/entity/')
+TGN = Namespace('https://vocab.getty.edu/tgn/')
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -443,6 +444,7 @@ def namespaces() -> Graph:
     output.bind('rism', RISM)
     output.bind('fg', FG)
     output.bind('isil', ISIL)
+    output.bind('tgn', TGN)
 
     # Return graph
     return output


### PR DESCRIPTION
Fixes #8 This merge enables the transformation of schema:keywords to cto:relatedLocation in case of TGN identifiers.