### PR TITLE
feat: default license check for cto and cto3 outputs, with optional disable of license check via --prepare CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ additional options:
 - `-ac` or `-add_catalog <uri>`: URI of a data catalog the data feed belongs to
 - `-ap` or `-add_publisher <uri>`: URI of the data publisher
 - `-c` or `--clean <string> <string>`: strings to remove from feed element URIs to build their file names
-- `-p` or `--prepare <string> <string>`: prepare cto output for this NFDI4Culture feed and catalog ID
+- `-p` or `--prepare <string> <string> <string>`: prepare cto output for this NFDI4Culture feed and catalog ID, dismiss license check optionally by adding 'no_license_check'
 - `-bu` or `--ba_username <string>`: Basic Auth username for requests
 - `-bp` or `--ba_password <string>`: Basic Auth password for requests
 - `-q` or `--quiet`: do not display status messages

--- a/base/organise.py
+++ b/base/organise.py
@@ -185,8 +185,8 @@ class Organise:
             '-p', '--prepare',
             default = None,
             type = str,
-            nargs = 2,
-            help = 'Prepare cto output for this NFDI4Culture feed and catalog ID'
+            nargs = '+',
+            help = 'Prepare cto output for this NFDI4Culture feed and catalog ID, optionally disable license check by adding "no_license_check".'
         )
         available_args.add_argument(
             '-bu', '--ba_username',
@@ -245,6 +245,13 @@ class Organise:
         if not self.elements:
             if 'beacon' in self.output or 'csv' in self.output or 'cto' in self.output or 'cto3' in self.output:
                 raise ValueError('Hydra Scraper called with extraction routine but no element markup.')
+
+        # Check given arguments in prepare
+        if self.prepare != None:
+            if len(self.prepare) < 2 or (len(self.prepare) == 2 and 'no_license_check' in self.prepare[:2]):
+                raise ValueError('Hydra Scraper expects NFDI4Culture feed and catalog ID in prepare. "no_license_check" can optionally be added as the third argument.')
+            elif len(self.prepare) == 3 and self.prepare[2] != 'no_license_check':
+                raise ValueError('Hydra Scraper expects "no_license_check" as the optional third argument in prepare.')
 
         # Check Basic Auth data
         if self.ba_username != None and self.ba_password == None:

--- a/map/cto.py
+++ b/map/cto.py
@@ -46,7 +46,7 @@ class Feed(MapFeedInterface):
         Generate nfdicore/cto-style feed triples and fill the store attribute
 
             Parameters:
-                prepare (list|None): Prepare cto output for this NFDI4Culture feed and catalog ID
+                prepare (list|None): Prepare cto output for this NFDI4Culture feed and catalog ID, disable license check optionally by adding 'no_license_check'.
         '''
 
         # Check requirements
@@ -56,7 +56,7 @@ class Feed(MapFeedInterface):
             self.rdf = namespaces()
 
             # Feed URI
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 feed_uri = URIRef(str(N4C) + prepare[0])
             else:
                 feed_uri = self.feed_uri.rdflib()
@@ -71,13 +71,13 @@ class Feed(MapFeedInterface):
                 self.rdf.add((feed_uri, SCHEMA.dateModified, Literal(str(today.isoformat()), datatype = XSD.date)))
 
             # Same as feed URI
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 self.rdf.add((feed_uri, OWL.sameAs, self.feed_uri.rdflib()))
             for i in self.feed_uri_same.rdflib():
                 self.rdf.add((feed_uri, OWL.sameAs, i))
 
             # Catalog URI
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 catalog_uri = URIRef(str(N4C) + prepare[1])
             else:
                 catalog_uri = self.catalog_uri.rdflib()
@@ -87,7 +87,7 @@ class Feed(MapFeedInterface):
                 self.rdf.add((catalog_uri, NFDICORE.dataset, feed_uri))
 
                 # Same as catalog URI
-                if prepare != None and len(prepare) == 2:
+                if prepare != None and len(prepare) >= 2:
                     self.rdf.add((catalog_uri, OWL.sameAs, self.catalog_uri.rdflib()))
                 for i in self.catalog_uri_same.rdflib():
                     self.rdf.add((catalog_uri, OWL.sameAs, i))
@@ -111,7 +111,7 @@ class FeedElement(MapFeedElementInterface):
         Generate nfdicore/cto-style feed element triples and fill the store attribute
 
             Parameters:
-                prepare (list|None): Prepare cto output for this NFDI4Culture feed and catalog ID
+                prepare (list|None): Prepare cto output for this NFDI4Culture feed and catalog ID, disable license check optionally by adding 'no_license_check'.
         '''
 
         # Check requirements
@@ -119,13 +119,15 @@ class FeedElement(MapFeedElementInterface):
             logger.error('Feed element URI missing')
         elif not self.feed_uri:
             logger.error('Feed URI missing')
+        elif not self.license and len(prepare) == 2:
+            logger.warning(f'No license attached to the feed element {self.element_uri}.')
         else:
             self.rdf = namespaces()
 
             # ELEMENT
 
             # Feed URI
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 feed_uri = URIRef(str(N4C) + prepare[0])
             else:
                 feed_uri = self.feed_uri.rdflib()
@@ -177,7 +179,7 @@ class FeedElement(MapFeedElementInterface):
                 self.rdf.add((self.element_uri.rdflib(), RDF.type, CTO.Item))
 
             # Optional wrapper
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 wrapper = element_ark(self.element_uri.text(), prepare[0])
                 self.rdf.add((feed_uri, SCHEMA.dataFeedElement, wrapper))
                 self.rdf.add((wrapper, RDF.type, SCHEMA.DataFeedItem))

--- a/map/cto3.py
+++ b/map/cto3.py
@@ -60,7 +60,7 @@ class Feed(MapFeedInterface):
         Generate nfdicore/cto-style feed triples and fill the store attribute
 
             Parameters:
-                prepare (list|None): Prepare cto output for this NFDI4Culture feed and catalog ID
+                prepare (list|None): Prepare cto output for this NFDI4Culture feed and catalog ID, disable license check optionally by adding 'no_license_check'.
         '''
 
         # Check requirements
@@ -70,7 +70,7 @@ class Feed(MapFeedInterface):
             self.rdf = namespaces()
 
             # Feed URI
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 feed_uri = URIRef(str(N4C) + prepare[0])
             else:
                 feed_uri = self.feed_uri.rdflib()
@@ -85,13 +85,13 @@ class Feed(MapFeedInterface):
                 self.rdf.add((feed_uri, SCHEMA.dateModified, Literal(str(today.isoformat()), datatype = XSD.date)))
 
             # Same as feed URI
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 self.rdf.add((feed_uri, SCHEMA.sameAs, self.feed_uri.rdflib()))
             for i in self.feed_uri_same.rdflib():
                 self.rdf.add((feed_uri, SCHEMA.sameAs, i))
 
             # Catalog URI
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 catalog_uri = URIRef(str(N4C) + prepare[1])
             else:
                 catalog_uri = self.catalog_uri.rdflib()
@@ -101,7 +101,7 @@ class Feed(MapFeedInterface):
                 self.rdf.add((catalog_uri, NFDICORE.NFDI_0000125, feed_uri)) # has data set
 
                 # Same as catalog URI
-                if prepare != None and len(prepare) == 2:
+                if prepare != None and len(prepare) >= 2:
                     self.rdf.add((catalog_uri, SCHEMA.sameAs, self.catalog_uri.rdflib()))
                 for i in self.catalog_uri_same.rdflib():
                     self.rdf.add((catalog_uri, SCHEMA.sameAs, i))
@@ -125,7 +125,7 @@ class FeedElement(MapFeedElementInterface):
         Generate nfdicore/cto-style feed element triples and fill the store attribute
 
             Parameters:
-                prepare (list|None): Prepare cto output for this NFDI4Culture feed and catalog ID
+                prepare (list|None): Prepare cto output for this NFDI4Culture feed and catalog ID, disable license check optionally by adding 'no_license_check'.
         '''
 
         # Check requirements
@@ -133,6 +133,8 @@ class FeedElement(MapFeedElementInterface):
             logger.error('Feed element URI missing')
         elif not self.feed_uri:
             logger.error('Feed URI missing')
+        elif not self.license and len(prepare) == 2:
+            logger.warning(f'No license attached to feed element {self.element_uri}.')
         else:
             self.rdf = namespaces()
 
@@ -157,14 +159,14 @@ class FeedElement(MapFeedElementInterface):
             self.rdf.add((self.element_uri.rdflib(), NFDICORE.NFDI_0001008, Literal(self.element_uri.uri, datatype = XSD.anyURI))) # has url
 
             # Feed URI
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 feed_uri = URIRef(str(N4C) + prepare[0])
             else:
                 feed_uri = self.feed_uri.rdflib()
             self.rdf.add((self.element_uri.rdflib(), CTO.CTO_0001006, feed_uri)) # is referenced in
 
             # Optional wrapper
-            if prepare != None and len(prepare) == 2:
+            if prepare != None and len(prepare) >= 2:
                 wrapper = element_ark(self.element_uri.text(), prepare[0])
                 self.rdf.add((feed_uri, SCHEMA.dataFeedElement, wrapper))
                 self.rdf.add((wrapper, RDF.type, SCHEMA.DataFeedItem))


### PR DESCRIPTION
note: with this commit, feed elements without a license statement are no longer serialized to CTO and CTO3 by default. users can optionally disable the license check via adding 'no_license_check' to the CLI argument --prepare.