### PR TITLE
feat: extract media byline also from schema:copyrightNotice

### DIFF
--- a/extract/schema.py
+++ b/extract/schema.py
@@ -217,7 +217,7 @@ class FeedElement(ExtractFeedElementInterface):
 
                     # Media byline (use dedicated property or, alternatively, author or creator)
                     if self.media:
-                        self.media.byline = LabelList(self.rdf_all_objects(self.media.uri.rdflib(), [SCHEMA.creditText, SDO.creditText]))
+                        self.media.byline = LabelList(self.rdf_all_objects(self.media.uri.rdflib(), [SCHEMA.creditText, SDO.creditText, SCHEMA.copyrightNotice, SDO.copyrightNotice]))
                         if not self.media.byline:
                             self.media.byline = LabelList(self.rdf_all_objects(self.media.uri.rdflib(), [SCHEMA.author, SDO.author]))
                         if not self.media.byline:


### PR DESCRIPTION
This PR enables the extraction of the media byline from schema:copyrightNotice in the source file as an alternative to schema:creditText.

Proposed to solve issue #14 